### PR TITLE
Add whitelist validation and noopener to popup

### DIFF
--- a/khb2025/js/popup.js
+++ b/khb2025/js/popup.js
@@ -1,3 +1,17 @@
 function openPopup(url) {
- window.open(url, '_blank', 'width=900, height=1200');
+  const allowedDomains = [window.location.hostname, 'forms.gle'];
+  let parsed;
+  try {
+    parsed = new URL(url, window.location.origin);
+  } catch (e) {
+    console.warn('Invalid URL:', url);
+    return;
+  }
+
+  if (!allowedDomains.includes(parsed.hostname)) {
+    console.warn('Blocked untrusted URL:', url);
+    return;
+  }
+
+  window.open(parsed.href, '_blank', 'width=900,height=1200,noopener');
 }


### PR DESCRIPTION
## Summary
- validate URLs against a whitelist before opening popups
- prevent reverse tabnabbing by opening new windows with `noopener`

## Testing
- `node - <<'NODE'
const fs = require('fs');
const vm = require('vm');
const code = fs.readFileSync('khb2025/js/popup.js', 'utf8');
const sandbox = {
  window: {
    location: { origin: 'https://example.com', hostname: 'example.com' },
    open: (...args) => { console.log('window.open called with', args); }
  },
  console,
  URL
};
vm.createContext(sandbox);
vm.runInContext(code, sandbox);
console.log('Test allowed same-origin relative URL');
sandbox.openPopup('submit.html');
console.log('Test allowed domain forms.gle');
sandbox.openPopup('https://forms.gle/test');
console.log('Test disallowed domain evil.com');
sandbox.openPopup('https://evil.com');
NODE`

------
https://chatgpt.com/codex/tasks/task_e_68c106f6d274832a9c3d643b5aeeb138