### PR TITLE
Strip disallowed attributes in haiku sanitizer

### DIFF
--- a/khb2024/battle/haiku.js
+++ b/khb2024/battle/haiku.js
@@ -2,9 +2,18 @@ function sanitizeHTML(str) {
   const template = document.createElement("template");
   template.innerHTML = str;
   const allowedTags = ["RUBY","RB","RT","RP","BR","SPAN"];
+  const allowedAttrs = {
+    SPAN: ["class"],
+  };
   template.content.querySelectorAll("*").forEach(el => {
     if (!allowedTags.includes(el.tagName)) {
       el.replaceWith(document.createTextNode(el.outerHTML));
+    } else {
+      el.getAttributeNames().forEach(attr => {
+        if (!(allowedAttrs[el.tagName] && allowedAttrs[el.tagName].includes(attr))) {
+          el.removeAttribute(attr);
+        }
+      });
     }
   });
   return template.innerHTML;

--- a/khb2025/battle/js/haiku.js
+++ b/khb2025/battle/js/haiku.js
@@ -68,9 +68,18 @@ function sanitizeHTML(str) {
   const template = document.createElement("template");
   template.innerHTML = str;
   const allowedTags = ["RUBY","RB","RT","RP","BR","SPAN"];
+  const allowedAttrs = {
+    SPAN: ["class"],
+  };
   template.content.querySelectorAll("*").forEach(el => {
     if (!allowedTags.includes(el.tagName)) {
       el.replaceWith(document.createTextNode(el.outerHTML));
+    } else {
+      el.getAttributeNames().forEach(attr => {
+        if (!(allowedAttrs[el.tagName] && allowedAttrs[el.tagName].includes(attr))) {
+          el.removeAttribute(attr);
+        }
+      });
     }
   });
   return template.innerHTML;


### PR DESCRIPTION
## Summary
- define allowedAttrs mapping (SPAN: class) in sanitizeHTML
- remove disallowed attributes from elements during sanitization

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check khb2024/battle/haiku.js`
- `node --check khb2025/battle/js/haiku.js`


------
https://chatgpt.com/codex/tasks/task_e_68c12298a054832aabd45889b15b70f2