### PR TITLE
Use textContent when sanitization unnecessary

### DIFF
--- a/khb2025/battle/A1/1.js
+++ b/khb2025/battle/A1/1.js
@@ -4,7 +4,7 @@ let whiteShown = false;
 function showRed() {
   if (!redShown) {
     redShown = true;
-    left.innerHTML = sanitizeHTML(teamname1[1][1]);//[1]が兼題１、[1]が先鋒句を意味する
+    left.textContent = teamname1[1][1];//[1]が兼題１、[1]が先鋒句を意味する
     btnA.style.display = "none";
   }
 }
@@ -12,7 +12,7 @@ function showRed() {
 function showWhite() {
   if (!whiteShown) {
     whiteShown = true;
-    right.innerHTML = sanitizeHTML(teamname2[1][1]);
+    right.textContent = teamname2[1][1];
     btnB.style.display = "none";
   }
 }

--- a/khb2025/battle/A1/3.js
+++ b/khb2025/battle/A1/3.js
@@ -4,7 +4,7 @@ let whiteShown = false;
 function showRed() {
   if (!redShown) {
     redShown = true;
-    left.innerHTML = sanitizeHTML(teamname1[1][3]);//[1]が兼題１、[3]が中堅句を意味する
+    left.textContent = teamname1[1][3];//[1]が兼題１、[3]が中堅句を意味する
     btnA.style.display = "none";
   }
 }
@@ -12,7 +12,7 @@ function showRed() {
 function showWhite() {
   if (!whiteShown) {
     whiteShown = true;
-    right.innerHTML = sanitizeHTML(teamname2[1][3]);
+    right.textContent = teamname2[1][3];
     btnB.style.display = "none";
   }
 }

--- a/khb2025/battle/A1/5.js
+++ b/khb2025/battle/A1/5.js
@@ -4,7 +4,7 @@ let whiteShown = false;
 function showRed() {
   if (!redShown) {
     redShown = true;
-    left.innerHTML = sanitizeHTML(teamname1[1][5]);//[1]が兼題１、[5]が大将句を意味する
+    left.textContent = teamname1[1][5];//[1]が兼題１、[5]が大将句を意味する
     btnA.style.display = "none";
   }
 }
@@ -12,7 +12,7 @@ function showRed() {
 function showWhite() {
   if (!whiteShown) {
     whiteShown = true;
-    right.innerHTML = sanitizeHTML(teamname2[1][5]);
+    right.textContent = teamname2[1][5];
     btnB.style.display = "none";
   }
 }

--- a/khb2025/battle/A2/1.js
+++ b/khb2025/battle/A2/1.js
@@ -4,7 +4,7 @@ let whiteShown = false;
 function showRed() {
   if (!redShown) {
     redShown = true;
-    left.innerHTML = sanitizeHTML(teamname2[2][1]);//[1]が兼題１、[1]が先鋒句を意味する
+    left.textContent = teamname2[2][1];//[1]が兼題１、[1]が先鋒句を意味する
     btnA.style.display = "none";
   }
 }
@@ -12,7 +12,7 @@ function showRed() {
 function showWhite() {
   if (!whiteShown) {
     whiteShown = true;
-    right.innerHTML = sanitizeHTML(teamname3[2][1]);
+    right.textContent = teamname3[2][1];
     btnB.style.display = "none";
   }
 }

--- a/khb2025/battle/A2/3.js
+++ b/khb2025/battle/A2/3.js
@@ -4,7 +4,7 @@ let whiteShown = false;
 function showRed() {
   if (!redShown) {
     redShown = true;
-    left.innerHTML = sanitizeHTML(teamname2[2][3]);//[1]が兼題１、[3]が中堅句を意味する
+    left.textContent = teamname2[2][3];//[1]が兼題１、[3]が中堅句を意味する
     btnA.style.display = "none";
   }
 }
@@ -12,7 +12,7 @@ function showRed() {
 function showWhite() {
   if (!whiteShown) {
     whiteShown = true;
-    right.innerHTML = sanitizeHTML(teamname3[2][3]);
+    right.textContent = teamname3[2][3];
     btnB.style.display = "none";
   }
 }

--- a/khb2025/battle/A2/5.js
+++ b/khb2025/battle/A2/5.js
@@ -4,7 +4,7 @@ let whiteShown = false;
 function showRed() {
   if (!redShown) {
     redShown = true;
-    left.innerHTML = sanitizeHTML(teamname2[2][5]);//[1]が兼題１、[5]が大将句を意味する
+    left.textContent = teamname2[2][5];//[1]が兼題１、[5]が大将句を意味する
     btnA.style.display = "none";
   }
 }
@@ -12,7 +12,7 @@ function showRed() {
 function showWhite() {
   if (!whiteShown) {
     whiteShown = true;
-    right.innerHTML = sanitizeHTML(teamname3[2][5]);
+    right.textContent = teamname3[2][5];
     btnB.style.display = "none";
   }
 }

--- a/khb2025/battle/A3/1.js
+++ b/khb2025/battle/A3/1.js
@@ -4,7 +4,7 @@ let whiteShown = false;
 function showRed() {
   if (!redShown) {
     redShown = true;
-    left.innerHTML = sanitizeHTML(teamname3[3][1]);//[1]が兼題１、[1]が先鋒句を意味する
+    left.textContent = teamname3[3][1];//[1]が兼題１、[1]が先鋒句を意味する
     btnA.style.display = "none";
   }
 }
@@ -12,7 +12,7 @@ function showRed() {
 function showWhite() {
   if (!whiteShown) {
     whiteShown = true;
-    right.innerHTML = sanitizeHTML(teamname1[3][1]);
+    right.textContent = teamname1[3][1];
     btnB.style.display = "none";
   }
 }

--- a/khb2025/battle/A3/3.js
+++ b/khb2025/battle/A3/3.js
@@ -4,7 +4,7 @@ let whiteShown = false;
 function showRed() {
   if (!redShown) {
     redShown = true;
-    left.innerHTML = sanitizeHTML(teamname3[3][3]);//[1]が兼題１、[3]が中堅句を意味する
+    left.textContent = teamname3[3][3];//[1]が兼題１、[3]が中堅句を意味する
     btnA.style.display = "none";
   }
 }
@@ -12,7 +12,7 @@ function showRed() {
 function showWhite() {
   if (!whiteShown) {
     whiteShown = true;
-    right.innerHTML = sanitizeHTML(teamname1[3][3]);
+    right.textContent = teamname1[3][3];
     btnB.style.display = "none";
   }
 }

--- a/khb2025/battle/A3/5.js
+++ b/khb2025/battle/A3/5.js
@@ -4,7 +4,7 @@ let whiteShown = false;
 function showRed() {
   if (!redShown) {
     redShown = true;
-    left.innerHTML = sanitizeHTML(teamname3[3][5]);//[1]が兼題１、[5]が大将句を意味する
+    left.textContent = teamname3[3][5];//[1]が兼題１、[5]が大将句を意味する
     btnA.style.display = "none";
   }
 }
@@ -12,7 +12,7 @@ function showRed() {
 function showWhite() {
   if (!whiteShown) {
     whiteShown = true;
-    right.innerHTML = sanitizeHTML(teamname1[3][5]);
+    right.textContent = teamname1[3][5];
     btnB.style.display = "none";
   }
 }

--- a/khb2025/battle/B1/1.js
+++ b/khb2025/battle/B1/1.js
@@ -4,7 +4,7 @@ let whiteShown = false;
 function showRed() {
   if (!redShown) {
     redShown = true;
-    left.innerHTML = sanitizeHTML(teamname4[1][1]);//[1]が兼題１、[1]が先鋒句を意味する
+    left.textContent = teamname4[1][1];//[1]が兼題１、[1]が先鋒句を意味する
     btnA.style.display = "none";
   }
 }
@@ -12,7 +12,7 @@ function showRed() {
 function showWhite() {
   if (!whiteShown) {
     whiteShown = true;
-    right.innerHTML = sanitizeHTML(teamname5[1][1]);
+    right.textContent = teamname5[1][1];
     btnB.style.display = "none";
   }
 }

--- a/khb2025/battle/B1/3.js
+++ b/khb2025/battle/B1/3.js
@@ -4,7 +4,7 @@ let whiteShown = false;
 function showRed() {
   if (!redShown) {
     redShown = true;
-    left.innerHTML = sanitizeHTML(teamname4[1][3]);//[1]が兼題１、[3]が中堅句を意味する
+    left.textContent = teamname4[1][3];//[1]が兼題１、[3]が中堅句を意味する
     btnA.style.display = "none";
   }
 }
@@ -12,7 +12,7 @@ function showRed() {
 function showWhite() {
   if (!whiteShown) {
     whiteShown = true;
-    right.innerHTML = sanitizeHTML(teamname5[1][3]);
+    right.textContent = teamname5[1][3];
     btnB.style.display = "none";
   }
 }

--- a/khb2025/battle/B1/5.js
+++ b/khb2025/battle/B1/5.js
@@ -4,7 +4,7 @@ let whiteShown = false;
 function showRed() {
   if (!redShown) {
     redShown = true;
-    left.innerHTML = sanitizeHTML(teamname4[1][5]);//[1]が兼題１、[5]が大将句を意味する
+    left.textContent = teamname4[1][5];//[1]が兼題１、[5]が大将句を意味する
     btnA.style.display = "none";
   }
 }
@@ -12,7 +12,7 @@ function showRed() {
 function showWhite() {
   if (!whiteShown) {
     whiteShown = true;
-    right.innerHTML = sanitizeHTML(teamname5[1][5]);
+    right.textContent = teamname5[1][5];
     btnB.style.display = "none";
   }
 }

--- a/khb2025/battle/B2/1.js
+++ b/khb2025/battle/B2/1.js
@@ -4,7 +4,7 @@ let whiteShown = false;
 function showRed() {
   if (!redShown) {
     redShown = true;
-    left.innerHTML = sanitizeHTML(teamname5[2][1]);//[1]が兼題１、[1]が先鋒句を意味する
+    left.textContent = teamname5[2][1];//[1]が兼題１、[1]が先鋒句を意味する
     btnA.style.display = "none";
   }
 }
@@ -12,7 +12,7 @@ function showRed() {
 function showWhite() {
   if (!whiteShown) {
     whiteShown = true;
-    right.innerHTML = sanitizeHTML(teamname6[2][1]);
+    right.textContent = teamname6[2][1];
     btnB.style.display = "none";
   }
 }

--- a/khb2025/battle/B2/3.js
+++ b/khb2025/battle/B2/3.js
@@ -4,7 +4,7 @@ let whiteShown = false;
 function showRed() {
   if (!redShown) {
     redShown = true;
-    left.innerHTML = sanitizeHTML(teamname5[2][3]);//[1]が兼題１、[3]が中堅句を意味する
+    left.textContent = teamname5[2][3];//[1]が兼題１、[3]が中堅句を意味する
     btnA.style.display = "none";
   }
 }
@@ -12,7 +12,7 @@ function showRed() {
 function showWhite() {
   if (!whiteShown) {
     whiteShown = true;
-    right.innerHTML = sanitizeHTML(teamname6[2][3]);
+    right.textContent = teamname6[2][3];
     btnB.style.display = "none";
   }
 }

--- a/khb2025/battle/B2/5.js
+++ b/khb2025/battle/B2/5.js
@@ -4,7 +4,7 @@ let whiteShown = false;
 function showRed() {
   if (!redShown) {
     redShown = true;
-    left.innerHTML = sanitizeHTML(teamname5[2][5]);//[1]が兼題１、[5]が大将句を意味する
+    left.textContent = teamname5[2][5];//[1]が兼題１、[5]が大将句を意味する
     btnA.style.display = "none";
   }
 }
@@ -12,7 +12,7 @@ function showRed() {
 function showWhite() {
   if (!whiteShown) {
     whiteShown = true;
-    right.innerHTML = sanitizeHTML(teamname6[2][5]);
+    right.textContent = teamname6[2][5];
     btnB.style.display = "none";
   }
 }

--- a/khb2025/battle/B3/1.js
+++ b/khb2025/battle/B3/1.js
@@ -4,7 +4,7 @@ let whiteShown = false;
 function showRed() {
   if (!redShown) {
     redShown = true;
-    left.innerHTML = sanitizeHTML(teamname6[3][1]);//[1]が兼題１、[1]が先鋒句を意味する
+    left.textContent = teamname6[3][1];//[1]が兼題１、[1]が先鋒句を意味する
     btnA.style.display = "none";
   }
 }
@@ -12,7 +12,7 @@ function showRed() {
 function showWhite() {
   if (!whiteShown) {
     whiteShown = true;
-    right.innerHTML = sanitizeHTML(teamname4[3][1]);
+    right.textContent = teamname4[3][1];
     btnB.style.display = "none";
   }
 }

--- a/khb2025/battle/B3/3.js
+++ b/khb2025/battle/B3/3.js
@@ -4,7 +4,7 @@ let whiteShown = false;
 function showRed() {
   if (!redShown) {
     redShown = true;
-    left.innerHTML = sanitizeHTML(teamname6[3][3]);//[1]が兼題１、[3]が中堅句を意味する
+    left.textContent = teamname6[3][3];//[1]が兼題１、[3]が中堅句を意味する
     btnA.style.display = "none";
   }
 }
@@ -12,7 +12,7 @@ function showRed() {
 function showWhite() {
   if (!whiteShown) {
     whiteShown = true;
-    right.innerHTML = sanitizeHTML(teamname4[3][3]);
+    right.textContent = teamname4[3][3];
     btnB.style.display = "none";
   }
 }

--- a/khb2025/battle/B3/5.js
+++ b/khb2025/battle/B3/5.js
@@ -4,7 +4,7 @@ let whiteShown = false;
 function showRed() {
   if (!redShown) {
     redShown = true;
-    left.innerHTML = sanitizeHTML(teamname6[3][5]);//[1]が兼題１、[5]が大将句を意味する
+    left.textContent = teamname6[3][5];//[1]が兼題１、[5]が大将句を意味する
     btnA.style.display = "none";
   }
 }
@@ -12,7 +12,7 @@ function showRed() {
 function showWhite() {
   if (!whiteShown) {
     whiteShown = true;
-    right.innerHTML = sanitizeHTML(teamname4[3][5]);
+    right.textContent = teamname4[3][5];
     btnB.style.display = "none";
   }
 }

--- a/khb2025/battle/final/1.js
+++ b/khb2025/battle/final/1.js
@@ -4,7 +4,7 @@ let whiteShown = false;
 function showRed() {
   if (!redShown) {
     redShown = true;
-    left.innerHTML = sanitizeHTML(teamnamefin1[4][1]);//[1]が兼題１、[1]が先鋒句を意味する
+    left.textContent = teamnamefin1[4][1];//[1]が兼題１、[1]が先鋒句を意味する
     btnA.style.display = "none";
   }
 }
@@ -12,7 +12,7 @@ function showRed() {
 function showWhite() {
   if (!whiteShown) {
     whiteShown = true;
-    right.innerHTML = sanitizeHTML(teamnamefin2[4][1]);
+    right.textContent = teamnamefin2[4][1];
     btnB.style.display = "none";
   }
 }

--- a/khb2025/battle/final/2.js
+++ b/khb2025/battle/final/2.js
@@ -4,7 +4,7 @@ let whiteShown = false;
 function showRed() {
   if (!redShown) {
     redShown = true;
-    left.innerHTML = sanitizeHTML(teamnamefin1[4][2]);//[1]が兼題１、[1]が先鋒句を意味する
+    left.textContent = teamnamefin1[4][2];//[1]が兼題１、[1]が先鋒句を意味する
     btnA.style.display = "none";
   }
 }

--- a/khb2025/battle/final/3.js
+++ b/khb2025/battle/final/3.js
@@ -4,7 +4,7 @@ let whiteShown = false;
 function showRed() {
   if (!redShown) {
     redShown = true;
-    left.innerHTML = sanitizeHTML(teamnamefin1[4][3]);//[1]が兼題１、[1]が先鋒句を意味する
+    left.textContent = teamnamefin1[4][3];//[1]が兼題１、[1]が先鋒句を意味する
     btnA.style.display = "none";
   }
 }
@@ -12,7 +12,7 @@ function showRed() {
 function showWhite() {
   if (!whiteShown) {
     whiteShown = true;
-    right.innerHTML = sanitizeHTML(teamnamefin2[4][3]);
+    right.textContent = teamnamefin2[4][3];
     btnB.style.display = "none";
   }
 }

--- a/khb2025/battle/final/4.js
+++ b/khb2025/battle/final/4.js
@@ -4,7 +4,7 @@ let whiteShown = false;
 function showRed() {
   if (!redShown) {
     redShown = true;
-    left.innerHTML = sanitizeHTML(teamnamefin1[4][4]);//[1]が兼題１、[1]が先鋒句を意味する
+    left.textContent = teamnamefin1[4][4];//[1]が兼題１、[1]が先鋒句を意味する
     btnA.style.display = "none";
   }
 }
@@ -12,7 +12,7 @@ function showRed() {
 function showWhite() {
   if (!whiteShown) {
     whiteShown = true;
-    right.innerHTML = sanitizeHTML(teamnamefin2[4][4]);
+    right.textContent = teamnamefin2[4][4];
     btnB.style.display = "none";
   }
 }

--- a/khb2025/battle/final/5.js
+++ b/khb2025/battle/final/5.js
@@ -4,7 +4,7 @@ let whiteShown = false;
 function showRed() {
   if (!redShown) {
     redShown = true;
-    left.innerHTML = sanitizeHTML(teamnamefin1[4][5]);//[1]が兼題１、[1]が先鋒句を意味する
+    left.textContent = teamnamefin1[4][5];//[1]が兼題１、[1]が先鋒句を意味する
     btnA.style.display = "none";
   }
 }
@@ -12,7 +12,7 @@ function showRed() {
 function showWhite() {
   if (!whiteShown) {
     whiteShown = true;
-    right.innerHTML = sanitizeHTML(teamnamefin2[4][5]);
+    right.textContent = teamnamefin2[4][5];
     btnB.style.display = "none";
   }
 }


### PR DESCRIPTION
## Summary
- Replace innerHTML+sanitizeHTML with textContent in match scripts lacking HTML tags
- Keep sanitizeHTML in final/2.js right side to allow ruby tag

## Testing
- `rg -n "innerHTML" khb2025/battle/{A1,A2,A3,B1,B2,B3,final}`

------
https://chatgpt.com/codex/tasks/task_e_68c122a95b0c832a89a4a2753e0f451d