### PR TITLE
Remove inline event handler and sanitize attributes

### DIFF
--- a/khb2024/battle/haiku.js
+++ b/khb2024/battle/haiku.js
@@ -2,10 +2,18 @@ function sanitizeHTML(str) {
   const template = document.createElement("template");
   template.innerHTML = str;
   const allowedTags = ["RUBY","RB","RT","RP","BR","SPAN"];
+  const allowedAttrs = { "SPAN": ["class"] };
   template.content.querySelectorAll("*").forEach(el => {
     if (!allowedTags.includes(el.tagName)) {
       el.replaceWith(document.createTextNode(el.outerHTML));
+      return;
     }
+    Array.from(el.attributes).forEach(attr => {
+      const tagAllowed = allowedAttrs[el.tagName] || [];
+      if (!tagAllowed.includes(attr.name.toLowerCase())) {
+        el.removeAttribute(attr.name);
+      }
+    });
   });
   return template.innerHTML;
 }

--- a/khb2025/battle/index.html
+++ b/khb2025/battle/index.html
@@ -52,7 +52,7 @@
 <br>
 <br>
 <br>
-<a href="" class="debugbtn" onclick="gate(); return false;">デバッグHOME</a>
+<a href="" class="debugbtn" id="debugbtn">デバッグHOME</a>
 </div>
 <script src="js/debug.js"></script>
 <script src="js/haiku.js"></script>

--- a/khb2025/battle/js/debug.js
+++ b/khb2025/battle/js/debug.js
@@ -1,4 +1,14 @@
-   function gate() {
-      var UserInput = prompt("デバッグページにアクセスすると，全チームの全投句を表示することになります．このことを理解してデバッグページにアクセスしたい場合は、以下に debug/debug_index と入力してください．","");
-      location.href = UserInput + ".html";
+function gate() {
+   var UserInput = prompt("デバッグページにアクセスすると，全チームの全投句を表示することになります．このことを理解してデバッグページにアクセスしたい場合は、以下に debug/debug_index と入力してください．","");
+   location.href = UserInput + ".html";
    }
+
+document.addEventListener('DOMContentLoaded', () => {
+   const debugBtn = document.getElementById('debugbtn');
+   if (debugBtn) {
+      debugBtn.addEventListener('click', (event) => {
+         event.preventDefault();
+         gate();
+      });
+   }
+});

--- a/khb2025/battle/js/haiku.js
+++ b/khb2025/battle/js/haiku.js
@@ -68,10 +68,18 @@ function sanitizeHTML(str) {
   const template = document.createElement("template");
   template.innerHTML = str;
   const allowedTags = ["RUBY","RB","RT","RP","BR","SPAN"];
+  const allowedAttrs = { "SPAN": ["class"] };
   template.content.querySelectorAll("*").forEach(el => {
     if (!allowedTags.includes(el.tagName)) {
       el.replaceWith(document.createTextNode(el.outerHTML));
+      return;
     }
+    Array.from(el.attributes).forEach(attr => {
+      const tagAllowed = allowedAttrs[el.tagName] || [];
+      if (!tagAllowed.includes(attr.name.toLowerCase())) {
+        el.removeAttribute(attr.name);
+      }
+    });
   });
   return template.innerHTML;
 }


### PR DESCRIPTION
## Summary
- replace debug button's inline handler with a JS event listener
- strip disallowed attributes in haiku sanitizers

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c122ac650c832ab71acdd31e07b6f7