### PR TITLE
Sanitize debug pages to render HTML safely

### DIFF
--- a/khb2025/battle/debug/debug1.js
+++ b/khb2025/battle/debug/debug1.js
@@ -1,19 +1,28 @@
-teamname.textContent = teamname1[0][0];
+function setSafeHTML(el, html) {
+  const tmp = document.createElement("div");
+  tmp.innerHTML = html;
+  tmp.querySelectorAll("script,iframe,object,link,style").forEach((node) =>
+    node.remove()
+  );
+  el.innerHTML = tmp.innerHTML;
+}
 
-k1_1.textContent = teamname1[1][1];
-k1_3.textContent = teamname1[1][3];
-k1_5.textContent = teamname1[1][5];
+setSafeHTML(teamname, teamname1[0][0]);
 
-k2_1.textContent = teamname1[2][1];
-k2_3.textContent = teamname1[2][3];
-k2_5.textContent = teamname1[2][5];
+setSafeHTML(k1_1, teamname1[1][1]);
+setSafeHTML(k1_3, teamname1[1][3]);
+setSafeHTML(k1_5, teamname1[1][5]);
 
-k3_1.textContent = teamname1[3][1];
-k3_3.textContent = teamname1[3][3];
-k3_5.textContent = teamname1[3][5];
+setSafeHTML(k2_1, teamname1[2][1]);
+setSafeHTML(k2_3, teamname1[2][3]);
+setSafeHTML(k2_5, teamname1[2][5]);
 
-k4_1.textContent = teamname1[4][1];
-k4_2.textContent = teamname1[4][2];
-k4_3.textContent = teamname1[4][3];
-k4_4.textContent = teamname1[4][4];
-k4_5.textContent = teamname1[4][5];
+setSafeHTML(k3_1, teamname1[3][1]);
+setSafeHTML(k3_3, teamname1[3][3]);
+setSafeHTML(k3_5, teamname1[3][5]);
+
+setSafeHTML(k4_1, teamname1[4][1]);
+setSafeHTML(k4_2, teamname1[4][2]);
+setSafeHTML(k4_3, teamname1[4][3]);
+setSafeHTML(k4_4, teamname1[4][4]);
+setSafeHTML(k4_5, teamname1[4][5]);

--- a/khb2025/battle/debug/debug2.js
+++ b/khb2025/battle/debug/debug2.js
@@ -1,19 +1,29 @@
-teamname.textContent = teamname2[0][0];
+function setSafeHTML(el, html) {
+  const tmp = document.createElement("div");
+  tmp.innerHTML = html;
+  tmp.querySelectorAll("script,iframe,object,link,style").forEach((node) =>
+    node.remove()
+  );
+  el.innerHTML = tmp.innerHTML;
+}
 
-k1_1.textContent = teamname2[1][1];
-k1_3.textContent = teamname2[1][3];
-k1_5.textContent = teamname2[1][5];
+setSafeHTML(teamname, teamname2[0][0]);
 
-k2_1.textContent = teamname2[2][1];
-k2_3.textContent = teamname2[2][3];
-k2_5.textContent = teamname2[2][5];
+setSafeHTML(k1_1, teamname2[1][1]);
+setSafeHTML(k1_3, teamname2[1][3]);
+setSafeHTML(k1_5, teamname2[1][5]);
 
-k3_1.textContent = teamname2[3][1];
-k3_3.textContent = teamname2[3][3];
-k3_5.textContent = teamname2[3][5];
+setSafeHTML(k2_1, teamname2[2][1]);
+setSafeHTML(k2_3, teamname2[2][3]);
+setSafeHTML(k2_5, teamname2[2][5]);
 
-k4_1.textContent = teamname2[4][1];
-k4_2.textContent = teamname2[4][2];
-k4_3.textContent = teamname2[4][3];
-k4_4.textContent = teamname2[4][4];
-k4_5.textContent = teamname2[4][5];
+setSafeHTML(k3_1, teamname2[3][1]);
+setSafeHTML(k3_3, teamname2[3][3]);
+setSafeHTML(k3_5, teamname2[3][5]);
+
+setSafeHTML(k4_1, teamname2[4][1]);
+setSafeHTML(k4_2, teamname2[4][2]);
+setSafeHTML(k4_3, teamname2[4][3]);
+setSafeHTML(k4_4, teamname2[4][4]);
+setSafeHTML(k4_5, teamname2[4][5]);
+

--- a/khb2025/battle/debug/debug3.js
+++ b/khb2025/battle/debug/debug3.js
@@ -1,19 +1,29 @@
-teamname.textContent = teamname3[0][0];
+function setSafeHTML(el, html) {
+  const tmp = document.createElement("div");
+  tmp.innerHTML = html;
+  tmp.querySelectorAll("script,iframe,object,link,style").forEach((node) =>
+    node.remove()
+  );
+  el.innerHTML = tmp.innerHTML;
+}
 
-k1_1.textContent = teamname3[1][1];
-k1_3.textContent = teamname3[1][3];
-k1_5.textContent = teamname3[1][5];
+setSafeHTML(teamname, teamname3[0][0]);
 
-k2_1.textContent = teamname3[2][1];
-k2_3.textContent = teamname3[2][3];
-k2_5.textContent = teamname3[2][5];
+setSafeHTML(k1_1, teamname3[1][1]);
+setSafeHTML(k1_3, teamname3[1][3]);
+setSafeHTML(k1_5, teamname3[1][5]);
 
-k3_1.textContent = teamname3[3][1];
-k3_3.textContent = teamname3[3][3];
-k3_5.textContent = teamname3[3][5];
+setSafeHTML(k2_1, teamname3[2][1]);
+setSafeHTML(k2_3, teamname3[2][3]);
+setSafeHTML(k2_5, teamname3[2][5]);
 
-k4_1.textContent = teamname3[4][1];
-k4_2.textContent = teamname3[4][2];
-k4_3.textContent = teamname3[4][3];
-k4_4.textContent = teamname3[4][4];
-k4_5.textContent = teamname3[4][5];
+setSafeHTML(k3_1, teamname3[3][1]);
+setSafeHTML(k3_3, teamname3[3][3]);
+setSafeHTML(k3_5, teamname3[3][5]);
+
+setSafeHTML(k4_1, teamname3[4][1]);
+setSafeHTML(k4_2, teamname3[4][2]);
+setSafeHTML(k4_3, teamname3[4][3]);
+setSafeHTML(k4_4, teamname3[4][4]);
+setSafeHTML(k4_5, teamname3[4][5]);
+

--- a/khb2025/battle/debug/debug4.js
+++ b/khb2025/battle/debug/debug4.js
@@ -1,19 +1,29 @@
-teamname.textContent = teamname4[0][0];
+function setSafeHTML(el, html) {
+  const tmp = document.createElement("div");
+  tmp.innerHTML = html;
+  tmp.querySelectorAll("script,iframe,object,link,style").forEach((node) =>
+    node.remove()
+  );
+  el.innerHTML = tmp.innerHTML;
+}
 
-k1_1.textContent = teamname4[1][1];
-k1_3.textContent = teamname4[1][3];
-k1_5.textContent = teamname4[1][5];
+setSafeHTML(teamname, teamname4[0][0]);
 
-k2_1.textContent = teamname4[2][1];
-k2_3.textContent = teamname4[2][3];
-k2_5.textContent = teamname4[2][5];
+setSafeHTML(k1_1, teamname4[1][1]);
+setSafeHTML(k1_3, teamname4[1][3]);
+setSafeHTML(k1_5, teamname4[1][5]);
 
-k3_1.textContent = teamname4[3][1];
-k3_3.textContent = teamname4[3][3];
-k3_5.textContent = teamname4[3][5];
+setSafeHTML(k2_1, teamname4[2][1]);
+setSafeHTML(k2_3, teamname4[2][3]);
+setSafeHTML(k2_5, teamname4[2][5]);
 
-k4_1.textContent = teamname4[4][1];
-k4_2.textContent = teamname4[4][2];
-k4_3.textContent = teamname4[4][3];
-k4_4.textContent = teamname4[4][4];
-k4_5.textContent = teamname4[4][5];
+setSafeHTML(k3_1, teamname4[3][1]);
+setSafeHTML(k3_3, teamname4[3][3]);
+setSafeHTML(k3_5, teamname4[3][5]);
+
+setSafeHTML(k4_1, teamname4[4][1]);
+setSafeHTML(k4_2, teamname4[4][2]);
+setSafeHTML(k4_3, teamname4[4][3]);
+setSafeHTML(k4_4, teamname4[4][4]);
+setSafeHTML(k4_5, teamname4[4][5]);
+

--- a/khb2025/battle/debug/debug5.js
+++ b/khb2025/battle/debug/debug5.js
@@ -1,19 +1,29 @@
-teamname.textContent = teamname5[0][0];
+function setSafeHTML(el, html) {
+  const tmp = document.createElement("div");
+  tmp.innerHTML = html;
+  tmp.querySelectorAll("script,iframe,object,link,style").forEach((node) =>
+    node.remove()
+  );
+  el.innerHTML = tmp.innerHTML;
+}
 
-k1_1.textContent = teamname5[1][1];
-k1_3.textContent = teamname5[1][3];
-k1_5.textContent = teamname5[1][5];
+setSafeHTML(teamname, teamname5[0][0]);
 
-k2_1.textContent = teamname5[2][1];
-k2_3.textContent = teamname5[2][3];
-k2_5.textContent = teamname5[2][5];
+setSafeHTML(k1_1, teamname5[1][1]);
+setSafeHTML(k1_3, teamname5[1][3]);
+setSafeHTML(k1_5, teamname5[1][5]);
 
-k3_1.textContent = teamname5[3][1];
-k3_3.textContent = teamname5[3][3];
-k3_5.textContent = teamname5[3][5];
+setSafeHTML(k2_1, teamname5[2][1]);
+setSafeHTML(k2_3, teamname5[2][3]);
+setSafeHTML(k2_5, teamname5[2][5]);
 
-k4_1.textContent = teamname5[4][1];
-k4_2.textContent = teamname5[4][2];
-k4_3.textContent = teamname5[4][3];
-k4_4.textContent = teamname5[4][4];
-k4_5.textContent = teamname5[4][5];
+setSafeHTML(k3_1, teamname5[3][1]);
+setSafeHTML(k3_3, teamname5[3][3]);
+setSafeHTML(k3_5, teamname5[3][5]);
+
+setSafeHTML(k4_1, teamname5[4][1]);
+setSafeHTML(k4_2, teamname5[4][2]);
+setSafeHTML(k4_3, teamname5[4][3]);
+setSafeHTML(k4_4, teamname5[4][4]);
+setSafeHTML(k4_5, teamname5[4][5]);
+

--- a/khb2025/battle/debug/debug6.js
+++ b/khb2025/battle/debug/debug6.js
@@ -1,19 +1,29 @@
-teamname.textContent = teamname6[0][0];
+function setSafeHTML(el, html) {
+  const tmp = document.createElement("div");
+  tmp.innerHTML = html;
+  tmp.querySelectorAll("script,iframe,object,link,style").forEach((node) =>
+    node.remove()
+  );
+  el.innerHTML = tmp.innerHTML;
+}
 
-k1_1.textContent = teamname6[1][1];
-k1_3.textContent = teamname6[1][3];
-k1_5.textContent = teamname6[1][5];
+setSafeHTML(teamname, teamname6[0][0]);
 
-k2_1.textContent = teamname6[2][1];
-k2_3.textContent = teamname6[2][3];
-k2_5.textContent = teamname6[2][5];
+setSafeHTML(k1_1, teamname6[1][1]);
+setSafeHTML(k1_3, teamname6[1][3]);
+setSafeHTML(k1_5, teamname6[1][5]);
 
-k3_1.textContent = teamname6[3][1];
-k3_3.textContent = teamname6[3][3];
-k3_5.textContent = teamname6[3][5];
+setSafeHTML(k2_1, teamname6[2][1]);
+setSafeHTML(k2_3, teamname6[2][3]);
+setSafeHTML(k2_5, teamname6[2][5]);
 
-k4_1.textContent = teamname6[4][1];
-k4_2.textContent = teamname6[4][2];
-k4_3.textContent = teamname6[4][3];
-k4_4.textContent = teamname6[4][4];
-k4_5.textContent = teamname6[4][5];
+setSafeHTML(k3_1, teamname6[3][1]);
+setSafeHTML(k3_3, teamname6[3][3]);
+setSafeHTML(k3_5, teamname6[3][5]);
+
+setSafeHTML(k4_1, teamname6[4][1]);
+setSafeHTML(k4_2, teamname6[4][2]);
+setSafeHTML(k4_3, teamname6[4][3]);
+setSafeHTML(k4_4, teamname6[4][4]);
+setSafeHTML(k4_5, teamname6[4][5]);
+

--- a/khb2025/battle/debug/debug_index.js
+++ b/khb2025/battle/debug/debug_index.js
@@ -1,6 +1,16 @@
-TEAM1.textContent = teamname1[0][0];
-TEAM2.textContent = teamname2[0][0];
-TEAM3.textContent = teamname3[0][0];
-TEAM4.textContent = teamname4[0][0];
-TEAM5.textContent = teamname5[0][0];
-TEAM6.textContent = teamname6[0][0];
+function setSafeHTML(el, html) {
+  const tmp = document.createElement("div");
+  tmp.innerHTML = html;
+  tmp.querySelectorAll("script,iframe,object,link,style").forEach((node) =>
+    node.remove()
+  );
+  el.innerHTML = tmp.innerHTML;
+}
+
+setSafeHTML(TEAM1, teamname1[0][0]);
+setSafeHTML(TEAM2, teamname2[0][0]);
+setSafeHTML(TEAM3, teamname3[0][0]);
+setSafeHTML(TEAM4, teamname4[0][0]);
+setSafeHTML(TEAM5, teamname5[0][0]);
+setSafeHTML(TEAM6, teamname6[0][0]);
+


### PR DESCRIPTION
## Summary
- Allow `<ruby>` and other HTML tags to render in battle debug pages by replacing `textContent` with sanitized HTML.
- Introduce `setSafeHTML` helper in each debug script and apply it to all team name and haiku fields.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c132c258fc832ab72e36e4fc5fecaa