### PR TITLE
Apply submit styles on confirm page

### DIFF
--- a/khb2026/confirm.html
+++ b/khb2026/confirm.html
@@ -5,6 +5,7 @@
   <title>関西俳句バトル2026　投句内容確認</title>
   <link rel="icon" href="../img/favicon.ico">
   <link rel="stylesheet" href="css/confirm.css">
+  <link rel="stylesheet" href="css/submit.css">
 </head>
 <body>
   <header>

--- a/khb2026/css/confirm.css
+++ b/khb2026/css/confirm.css
@@ -38,7 +38,6 @@ header a {
     right: 0;
     display: flex;
     gap: 0.5rem;
-    background-color: var(--pastelgreen);
     padding: 0.5rem;
 }
 .btn-menu {


### PR DESCRIPTION
## Summary
- include the submit stylesheet on the confirmation page so its buttons share the same styling
- remove the extra background fill from the confirmation header button area to match the surrounding theme

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c87d8e5834832aac4ac70b5ef0ae3a