### PR TITLE
Prevent double submission of final form

### DIFF
--- a/khb2026/js/confirm.js
+++ b/khb2026/js/confirm.js
@@ -14,6 +14,7 @@ document.addEventListener('DOMContentLoaded', () => {
   });
 
   const form = document.getElementById('finalForm');
+  const submitBtn = document.getElementById('finalSubmit');
   if (!form) {
     return;
   }
@@ -29,7 +30,15 @@ document.addEventListener('DOMContentLoaded', () => {
     form.appendChild(input);
   });
 
-  form.addEventListener('submit', () => {
+  form.addEventListener('submit', event => {
+    if (window.submitted) {
+      event.preventDefault();
+      return;
+    }
+    window.submitted = true;
+    if (submitBtn) {
+      submitBtn.disabled = true;
+    }
     sessionStorage.clear();
   });
 


### PR DESCRIPTION
## Summary
- disable the final submit button once it has been used
- prevent additional submit events when the form has already been submitted

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c87d8f2650832a98ae686ef1006d14