### PR TITLE
Fix duplicate IDs on KHB 2026 confirm page

### DIFF
--- a/khb2026/confirm.html
+++ b/khb2026/confirm.html
@@ -17,67 +17,67 @@
   </header>
   <section id="top">
     <div id="wrapper">
-      <div id="right2">
+      <div class="right2">
         <h3>大将</h3>
         <div class="right"><div id="k4_5" class="kunakami"></div></div>
       </div>
-      <div id="left2">
+      <div class="left2">
         <h3>副将</h3>
         <div class="left"><div id="k4_4" class="kunakami"></div></div>
       </div>
-      <div id="right2">
+      <div class="right2">
         <h3>中堅</h3>
         <div class="right"><div id="k4_3" class="kunakami"></div></div>
       </div>
-      <div id="left2">
+      <div class="left2">
         <h3>次鋒</h3>
         <div class="left"><div id="k4_2" class="kunakami"></div></div>
       </div>
-      <div id="right2">
+      <div class="right2">
         <h3>先鋒</h3>
         <div class="left"><div id="k4_1" class="kunakami"></div></div>
       </div>
       <div class="space"><div id="kendai4"></div></div>
-      <div id="left2">
+      <div class="left2">
         <h3>大将</h3>
         <div class="left"><div id="k3_5" class="kunakami"></div></div>
       </div>
-      <div id="right2">
+      <div class="right2">
         <h3>中堅</h3>
         <div class="right"><div id="k3_3" class="kunakami"></div></div>
       </div>
-      <div id="left2">
+      <div class="left2">
         <h3>先鋒</h3>
         <div class="left"><div id="k3_1" class="kunakami"></div></div>
       </div>
       <div class="space"><div id="kendai3"></div></div>
-      <div id="right2">
+      <div class="right2">
         <h3>大将</h3>
         <div class="right"><div id="k2_5" class="kunakami"></div></div>
       </div>
-      <div id="left2">
+      <div class="left2">
         <h3>中堅</h3>
         <div class="left"><div id="k2_3" class="kunakami"></div></div>
       </div>
-      <div id="right2">
+      <div class="right2">
         <h3>先鋒</h3>
         <div class="right"><div id="k2_1" class="kunakami"></div></div>
       </div>
       <div class="space"><div id="kendai2"></div></div>
-      <div id="left2">
+      <div class="left2">
         <h3>大将</h3>
         <div class="left"><div id="k1_5" class="kunakami"></div></div>
       </div>
-      <div id="right2">
+      <div class="right2">
         <h3>中堅</h3>
         <div class="right"><div id="k1_3" class="kunakami"></div></div>
       </div>
-      <div id="left2">
+      <div class="left2">
         <h3>先鋒</h3>
         <div class="left"><div id="k1_1" class="kunakami"></div></div>
       </div>
       <div class="space"><div id="kendai1"></div></div>
-      <div id="right2">
+      <div class="right2">
         <h3></h3>
         <div class="right"><div id="teamName" class="kunakami"></div></div>
       </div>

--- a/khb2026/css/confirm.css
+++ b/khb2026/css/confirm.css
@@ -51,7 +51,7 @@ h3 {
     padding-bottom: 1.5rem;
 }
 
-#left2 {
+.left2 {
     list-style-position: inside;
     text-align: center;
     float: left;
@@ -61,7 +61,7 @@ h3 {
     background: #ffccff;
     border: 2px solid #000000;
 }
-#right2 {
+.right2 {
     list-style-position: inside;
     text-align: center;
     float: left;

--- a/khb2026/js/kintou.js
+++ b/khb2026/js/kintou.js
@@ -62,7 +62,7 @@
         const element = document.getElementById(elementId);
         if (element && element.textContent.trim()) {
           // コンテナの高さを計算（親要素の高さから余白を除く）
-          const parent = element.closest('#left2, #right2');
+          const parent = element.closest('.left2, .right2');
           if (parent) {
             const parentHeight = parent.clientHeight;
             const h3Height = parent.querySelector('h3').offsetHeight;
@@ -104,7 +104,7 @@
     
     // 利用可能な高さを計算する補助関数
     function getAvailableHeight(element) {
-      const parent = element.closest('#left2, #right2');
+      const parent = element.closest('.left2, .right2');
       if (parent) {
         const parentHeight = parent.clientHeight;
         const h3 = parent.querySelector('h3');


### PR DESCRIPTION
## Summary
- replace duplicate `right2`/`left2` IDs on the KHB 2026 confirm page with classes
- update the corresponding stylesheet and layout script to target the new classes

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c930fb7e90832a869480e371619efd