### PR TITLE
Fix confirm button visibility

### DIFF
--- a/khb2026/css/color.css
+++ b/khb2026/css/color.css
@@ -2,6 +2,7 @@
 :root {
     --grey: #333;
     --white: #fff;
+    --black: #111;
     --accent: #7fdcff;
     --deepaccent: #00b8f4;
     --pastelaccent: #bfeaff;

--- a/khb2026/submit.html
+++ b/khb2026/submit.html
@@ -63,7 +63,7 @@
                     <label for="agree">投句は、すべて自作・未発表であることを宣誓します。また、投句内容に誤りがないことを確認しました。</label>
                 </p>
                 
-                <input id="submitting" class="submit" type="submit" value="確認へ">
+                <input id="submitting" class="submit" type="submit" value="確認画面へ">
             </form>
 
         </div>


### PR DESCRIPTION
## Summary
- add the missing black color token used by the submit button styles
- update the submission button label to read "確認画面へ"

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc5c71d068832ab7f0ded924e89e06